### PR TITLE
FEAT(DatabaseController): Added TRUNCATE endpoints for group-related tables.

### DIFF
--- a/src/main/java/com/copay/app/controller/DatabaseController.java
+++ b/src/main/java/com/copay/app/controller/DatabaseController.java
@@ -30,4 +30,34 @@ public class DatabaseController {
 
 		return "User reset successful!";
 	}
+
+	@PostMapping("/reset-group-members")
+	public String resetGroupMembersTable() {
+
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+		jdbcTemplate.execute("TRUNCATE TABLE group_members");
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+
+		return "Group members reset successful!";
+	}
+
+	@PostMapping("/reset-external-members")
+	public String resetExternalMembersTable() {
+
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+		jdbcTemplate.execute("TRUNCATE TABLE external_members");
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+
+		return "External members reset successful!";
+	}
+
+	@PostMapping("/reset-groups")
+	public String resetGroupsTable() {
+
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+		jdbcTemplate.execute("TRUNCATE TABLE `groups`");
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+
+		return "Groups reset successful!";
+	}
 }


### PR DESCRIPTION
- Implemented TRUNCATE endpoints for the following tables:

  - `group_members` table (`/reset-group-members` endpoint).

  - `external_members` table (`/reset-external-members` endpoint).

  - `groups` table (`/reset-groups` endpoint).

- Added logic to disable foreign key checks temporarily (`SET FOREIGN_KEY_CHECKS = 0`) to avoid issues when truncating tables with foreign key dependencies.

- Ensured that foreign key checks are re-enabled after the TRUNCATE operation (`SET FOREIGN_KEY_CHECKS = 1`).

- Each TRUNCATE operation must be performed in a specific order to respect foreign key constraints:

  - `group_members` first.

  - `external_members` second.

  - `groups` last.

Closes #144.